### PR TITLE
Use export to access variables in xargs

### DIFF
--- a/stages/01_download.sh
+++ b/stages/01_download.sh
@@ -13,7 +13,7 @@ mkdir -p $listpath
 cd $listpath;
 
 # Define the FTP base address
-ftpbase=""
+export ftpbase=""
 
 # Retrieve the list of files to download from FTP base address
 wget --no-remove-listing $ftpbase
@@ -22,14 +22,15 @@ rm .listing
 rm index.html
 
 # Create the download directory
-downloadpath="$localpath/download"
+export downloadpath="$localpath/download"
 echo "Download path: $downloadpath"
 mkdir -p "$downloadpath"
 cd $downloadpath;
 
 # Download files in parallel
 cat $listpath/files.txt | xargs -P14 -n1 bash -c '
-echo $0
-wget -nH -q -nc -P '$downloadpath' '$ftpbase'$0'
+  echo $0
+  wget -nH -q -nc -P $downloadpath $ftpbase$0
+'
 
 echo "Download done."

--- a/stages/02_unzip.sh
+++ b/stages/02_unzip.sh
@@ -7,7 +7,7 @@ localpath=$(pwd)
 echo "Local path: $localpath"
 
 # Set download path
-downloadpath="$localpath/download"
+export downloadpath="$localpath/download"
 echo "Download path: $downloadpath"
 
 # Set list path
@@ -15,14 +15,14 @@ listpath="$localpath/list"
 echo "List path: $listpath"
 
 # Create raw path
-rawpath="$localpath/raw"
+export rawpath="$localpath/raw"
 mkdir -p $rawpath
 echo "Raw path: $rawpath"
 
 # Unzip files in parallel
 cat $listpath/files.txt | tail -n +2 | xargs -P14 -n1 bash -c '
   filename="${0%.*}"
-  echo '$downloadpath'/$0
-  echo '$rawpath'/$filename
-  unzip '$downloadpath'/$0 -d '$rawpath'/$filename
+  echo $downloadpath/$0
+  echo $rawpath/$filename
+  unzip $downloadpath/$0 -d $rawpath/$filename
 '

--- a/stages/03_build.sh
+++ b/stages/03_build.sh
@@ -12,11 +12,11 @@ mkdir -p $listpath
 echo "List path: $listpath"
 
 # Set raw path
-rawpath="$localpath/raw"
+export rawpath="$localpath/raw"
 echo "Raw path: $rawpath"
 
 # Create brick directory
-brickpath="$localpath/brick"
+export brickpath="$localpath/brick"
 mkdir -p $brickpath
 echo "Brick path: $brickpath"
 
@@ -24,7 +24,7 @@ echo "Brick path: $brickpath"
 # calling a Python function with arguments input and output filenames
 cat $listpath/files.txt | tail -n +4 | xargs -P14 -n1 bash -c '
   filename="${0%.*}"
-  echo '$rawpath'/$filename/$filename.txt
-  echo '$brickpath'/$filename.parquet
-  python stages/csv2parquet.py '$rawpath'/$filename.txt '$brickpath'/$filename.parquet
+  echo $rawpath/$filename/$filename.txt
+  echo $brickpath/$filename.parquet
+  python stages/csv2parquet.py $rawpath/$filename.txt $brickpath/$filename.parquet
 '


### PR DESCRIPTION
instead of concatenation.

Fixes <https://github.com/biobricks-ai/brick-template/issues/3>.
