### PR TITLE
Clear `stages` key in `dvc.lock`

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,12 +1,2 @@
 schema: '2.0'
-stages:
-  1-stage:
-    cmd: Rscript stages/01-stage.R
-    deps:
-    - path: stages/01-stage.R
-      md5: c468dc14527e00c339f146e1dba2bd3b
-      size: 118
-    outs:
-    - path: data/mtcars.parquet
-      md5: 77cf29accf9535522fad7db1486eff9a
-      size: 6243
+stages: {}


### PR DESCRIPTION
This is so that future bricks do not bring in the unused stage.

Connects with <https://github.com/biobricks-ai/biobricks-okg/issues/27>.
